### PR TITLE
Modernize Travis CI NodeJS build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
+  - 5
+  - 4
+  - 0.12
+  - 0.10
   - 0.8
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
Updates the Travis CI build matrix to test NodeJS versions 0.10.x, 0.12.x, 4.x.x, and 5.x.x
